### PR TITLE
fix: no need to create another url variable when open app settings

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Util/DoraemonUtil.m
+++ b/iOS/DoraemonKit/Src/Core/Util/DoraemonUtil.m
@@ -283,7 +283,6 @@
 + (void)openAppSetting{
     NSURL * url = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
     if([[UIApplication sharedApplication] canOpenURL:url]) {
-        NSURL*url =[NSURL URLWithString:UIApplicationOpenSettingsURLString];
         if (@available(iOS 10.0, *)) {
             [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {
                 


### PR DESCRIPTION
It is not needed create a new url variable, the previous one URL variable can be used instead.

Tested on iPhone 11 with iOS 14.5.1 and it works correctly