### PR TITLE
解决和HttpLoggingInterceptor冲突问题

### DIFF
--- a/Android/dokit/src/main/java/com/didichuxing/doraemonkit/kit/weaknetwork/SpeedLimitRequestBody.java
+++ b/Android/dokit/src/main/java/com/didichuxing/doraemonkit/kit/weaknetwork/SpeedLimitRequestBody.java
@@ -38,11 +38,9 @@ public class SpeedLimitRequestBody extends RequestBody {
 
     @Override
     public void writeTo(BufferedSink sink) throws IOException {
-        if (mBufferedSink == null) {
-            //mBufferedSink = Okio.buffer(sink(sink));
-            //默认8K 精确到1K
-            mBufferedSink = OkHttpWrap.INSTANCE.createByteCountBufferedSink(sink(sink), 1024L);
-        }
+        //mBufferedSink = Okio.buffer(sink(sink));
+        //默认8K 精确到1K
+        mBufferedSink = OkHttpWrap.INSTANCE.createByteCountBufferedSink(sink(sink), 1024L);
         mRequestBody.writeTo(mBufferedSink);
         mBufferedSink.close();
     }


### PR DESCRIPTION
HttpLoggingInterceptor打印body调用requestBody.writeTo(buffer) 时 mBufferedSink 已经被close，真实请求时就会报 [DokitCapInterceptor]: e===>closed