### PR TITLE
fix(Ios):fix "_statusBarWindow"  with ios16 crash

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Plugin/UI/ViewMetrics/Function/UIView+DoraemonViewMetrics.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/UI/ViewMetrics/Function/UIView+DoraemonViewMetrics.m
@@ -39,8 +39,8 @@
 - (void)doraemonMetricsRecursiveEnable:(BOOL)enable
 {
     // 状态栏不显示元素边框
-    UIWindow *statusBarWindow = [[UIApplication sharedApplication] valueForKey:@"_statusBarWindow"];
-    if (statusBarWindow && [self isDescendantOfView:statusBarWindow]) {
+    UIView * statusBarView =  [[UIApplication sharedApplication] valueForKey:@"_statusBar"];
+    if(statusBarView && [self isDescendantOfView:statusBarView.window]){
         return;
     }
 


### PR DESCRIPTION
修复了 issues里面 标题为：" ios xcode 14，14 Pro。打开布局边框之后出现崩溃。 #1077 " [https://github.com/didi/DoKit/issues/1077](url) 的bug。