### PR TITLE
bug(android):处理卡顿检测时，容易触发发现卡顿 但是收集不到 堆栈的bug

### DIFF
--- a/Android/dokit/src/main/java/com/didichuxing/doraemonkit/kit/blockmonitor/core/MonitorCore.java
+++ b/Android/dokit/src/main/java/com/didichuxing/doraemonkit/kit/blockmonitor/core/MonitorCore.java
@@ -14,8 +14,11 @@ class MonitorCore implements Printer {
     private static final String TAG = "MonitorCore";
     /**
      * 卡顿阈值
+     * 该值必须大于 StackSampler 中的 DEFAULT_SAMPLE_INTERVAL 采样间隔
+     * 否则会出现 发现卡顿 但是采集不到堆栈的问题
+     *
      */
-    private static final int BLOCK_THRESHOLD_MILLIS = 200;
+    private static final int BLOCK_THRESHOLD_MILLIS = 250;
 
     private long mStartTime = 0;
     private long mStartThreadTime = 0;

--- a/Android/dokit/src/main/java/com/didichuxing/doraemonkit/kit/blockmonitor/core/StackSampler.java
+++ b/Android/dokit/src/main/java/com/didichuxing/doraemonkit/kit/blockmonitor/core/StackSampler.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class StackSampler {
     private static final String TAG = "StackSampler";
-    private static final int DEFAULT_SAMPLE_INTERVAL = 300;
+    private static final int DEFAULT_SAMPLE_INTERVAL = 200;
     private static final int DEFAULT_MAX_ENTRY_COUNT = 100;
     private static final String SEPARATOR = "\r\n";
     private static final SimpleDateFormat TIME_FORMATTER =


### PR DESCRIPTION
堆栈检测默认是300ms采集，如果小于这个间隔则会stop dump，从消息队列中移除。
卡顿检测默认阈值是200ms。

如果一个卡顿是250ms，例如可以把dokit demo中的 BlockMonitorFragment 中的 mockBlock 方法中的 sleep(2000) 改成sleep(250)

此时就会出现能检测到卡顿，isBlock返回true，但是因为只有250ms的卡顿，还不到300ms所以直接stopDump 导致无法收集到堆栈